### PR TITLE
Fixed shared/static library build config

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -10,6 +10,13 @@ set (sources mman.c)
 
 add_library (mman ${sources})
 
+if (BUILD_SHARED_LIBS)
+	target_compile_definitions(mman
+		PUBLIC MMAN_LIBRARY_DLL
+		PRIVATE MMAN_LIBRARY
+	)
+endif()
+
 install (TARGETS mman RUNTIME DESTINATION bin
                       LIBRARY DESTINATION lib${LIB_SUFFIX}
                       ARCHIVE DESTINATION lib${LIB_SUFFIX})

--- a/Makefile
+++ b/Makefile
@@ -13,6 +13,7 @@ endif
 ifeq ($(BUILD_SHARED),yes)
 	TARGETS+=libmman.dll
 	INSTALL+=shared-install
+	CFLAGS+=-DMMAN_LIBRARY_DLL -DMMAN_LIBRARY
 endif
 
 ifeq ($(BUILD_MSVC),yes)

--- a/mman-win32.pro
+++ b/mman-win32.pro
@@ -2,8 +2,8 @@ QT -= core gui
 
 TARGET = mman
 TEMPLATE = lib
-# CONFIG += staticlib
 
+DEFINES += MMAN_LIBRARY_DLL
 DEFINES += MMAN_LIBRARY
 
 HEADERS += \

--- a/mman.h
+++ b/mman.h
@@ -15,11 +15,18 @@
 #include <_mingw.h>
 #endif
 
+#if defined(MMAN_LIBRARY_DLL)
+/* Windows shared libraries (DLL) must be declared export when building the lib and import when building the 
+application which links against the library. */
 #if defined(MMAN_LIBRARY)
 #define MMANSHARED_EXPORT __declspec(dllexport)
 #else
 #define MMANSHARED_EXPORT __declspec(dllimport)
-#endif
+#endif /* MMAN_LIBRARY */
+#else
+/* Static libraries do not require a __declspec attribute.*/
+#define MMANSHARED_EXPORT
+#endif /* MMAN_LIBRARY_DLL */
 
 /* Determine offset type */
 #include <stdint.h>


### PR DESCRIPTION
As it was building static libraries correctly was not possible because MMANSHARED_EXPORT was always defined.

* Added MMAN_LIBRARY_DLL which is defined for shared library builds to allow proper static library builds.
* Updated build files to dfeine MMAN_LIBRARY_DLL.
* Updated CMakeLists to respect BUILD_SHARED_LIBS flag.