### PR TITLE
Added --bindir install option to configure so we can specify the bind…

### DIFF
--- a/configure
+++ b/configure
@@ -35,6 +35,7 @@ show_help(){
   echo
   echo "  --help                    print this message"
   echo "  --prefix=PREFIX           install in PREFIX [$PREFIX]"
+  echo "  --bindir=DIR              install binaries in DIR [$PREFIX/bin]"
   echo "  --libdir=DIR              install libs in DIR [$PREFIX/lib]"
   echo "  --incdir=DIR              install includes in DIR [$PREFIX/include]"
   echo "  --enable-static           build static libraries [yes]"
@@ -87,6 +88,9 @@ for opt do
     ;;
     --prefix=*)
         PREFIX="$optval"
+    ;;
+    --bindir=*)
+        bindir="$optval"
     ;;
     --libdir=*)
         libdir="$optval"


### PR DESCRIPTION
bindir, in the configure file, isn't tied to PREFIX, and there's no way to override it. For now, I'm simply going to add a override paramter to ./configure to match the libdir and incdir options.

In the future we will either want to remove bindir from the configure file all together, and/or tie bindir, libdir, and incdir to PREFIX (e.g. when you override PREFIX bindir, incdir, and libdir should also be set, at the same time.)